### PR TITLE
Change http status code of maintenance page in UAbierta

### DIFF
--- a/uabierta/Dockerfile
+++ b/uabierta/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:latest
 
-COPY ./page/ /usr/share/nginx/html/
+COPY ./page/ /usr/local/nginx/html/
 
 COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/uabierta/default.conf
+++ b/uabierta/default.conf
@@ -1,21 +1,41 @@
 server {
-    listen       80;
-    server_name  localhost;
+    listen 80 default;
+    server_name localhost;
 
-    #access_log  /var/log/nginx/host.access.log  main;
+    index index.html;
+    limit_conn  gulag 50;
+    root /usr/local/nginx/html;
+
+    ## Only requests to our Host are allowed
+    if ($host !~ ^(uabierta.uchile.cl)$ ) {
+        return 444;
+    }
+
+    # Only allow these request methods
+    if ($request_method !~ ^(GET|HEAD|POST)$ ) {
+        return 444;
+    }
 
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        if (-f $document_root/index.html) {
+            return 503;
+        }
     }
-
-    error_page  404              /index.html;
 
     # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
+    error_page 500 502 504 /50x.html;
     location = /50x.html {
-        root   /usr/share/nginx/html;
+        root html;
     }
-
+    # error 403 
+    error_page 403 /error403.html;
+    location = /error403.html {
+        root html;
+        allow all;
+    }
+    # error 503 redirect to our maintenance page
+    error_page 503 @maintenance;
+    location @maintenance {
+        rewrite ^(.*)$ /index.html break;
+    }
 }


### PR DESCRIPTION
Cambia el stauts code de 404 a 503 porque es lo recomendado para sistemas en mantención ya que de ese modo nadie hace caché de la respuesta.
Además, cambia el punto de montaje de la página en el container para no perder las demás páginas de error provistas por nginx.

Refs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503 y https://www.cyberciti.biz/faq/custom-nginx-maintenance-page-with-http503/